### PR TITLE
Add OpenAPI sync script

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,3 +119,17 @@ Zur Steuerung der Agenten können folgende Kommandos in PRs oder Commit-Messages
 ## Fragen?
 
 Bei Unsicherheiten bitte Rücksprache mit dem Projektteam halten oder einen PR mit `@review` markieren.
+
+## OpenAPI-Synchronisation
+
+Mit dem Skript `sync-openapi.js` kann aus jeder Postman-Collection automatisch
+eine OpenAPI-Datei erzeugt werden. Die generierten YAML-Dateien landen im
+Verzeichnis `open-api/` und tragen den Namen aus `info.name` der jeweiligen
+Collection.
+
+Aufruf:
+
+```bash
+node sync-openapi.js
+```
+

--- a/sync-openapi.js
+++ b/sync-openapi.js
@@ -1,0 +1,22 @@
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+const collectionsDir = path.join(__dirname, 'postman', 'collections');
+const outputDir = path.join(__dirname, 'open-api');
+
+if (!fs.existsSync(outputDir)) {
+  fs.mkdirSync(outputDir, { recursive: true });
+}
+
+const files = fs.readdirSync(collectionsDir).filter(f => f.endsWith('.json'));
+
+files.forEach(file => {
+  const collectionPath = path.join(collectionsDir, file);
+  const json = JSON.parse(fs.readFileSync(collectionPath, 'utf8'));
+  const name = json.info && json.info.name ? json.info.name : path.parse(file).name;
+  const openapiPath = path.join(outputDir, `${name}.yaml`);
+  const cmd = `npx -y postman-to-openapi "${collectionPath}" "${openapiPath}" -y`;
+  console.log(`Converting ${file} -> ${openapiPath}`);
+  execSync(cmd, { stdio: 'inherit' });
+});


### PR DESCRIPTION
## Summary
- add Node script `sync-openapi.js` to convert collections to OpenAPI
- store results under `open-api/`
- document usage in README

## Testing
- `node sync-openapi.js` *(fails: 403 Forbidden when installing postman-to-openapi)*

------
https://chatgpt.com/codex/tasks/task_e_684ac70fd71083258db3e470f8559eb2